### PR TITLE
Fix issues with some post notification email being flagged as suspicious

### DIFF
--- a/models/conversation_post.rb
+++ b/models/conversation_post.rb
@@ -103,18 +103,6 @@ class ConversationPost
   def self.dmarc_fail_domains
     %w{yahoo.com aol.com protonmail.com} + (Config['DMARC_FAIL_DOMAINS'] ? Config['DMARC_FAIL_DOMAINS'].split(',') : [])
   end
-
-  def from_address
-    group = conversation.group
-    from = account.email
-    if Config['HIDE_ACCOUNT_EMAIL']
-      group.email
-    elsif ConversationPost.dmarc_fail_domains.include?(from.split('@').last)
-      group.email('-noreply')
-    else
-      from
-    end
-  end    
    
   def accounts_to_notify   
     Account.where(:id.in => (group.memberships.where(:status => 'confirmed').where(:notification_level => 'each').pluck(:account_id) - conversation.conversation_mutes.pluck(:account_id)))

--- a/models/conversation_post_bcc.rb
+++ b/models/conversation_post_bcc.rb
@@ -66,11 +66,7 @@ class ConversationPostBcc
                 
     mail = Mail.new
     mail.to = group.email
-    if Config['REPLY_TO_GROUP']
-      mail.reply_to = group.email 
-    end
-    mail.from = "#{conversation_post.account.name} <#{conversation_post.from_address}>"
-    mail.sender = group.email('-noreply')
+    mail.from = group.email 
     mail.subject = conversation.visible_conversation_posts.count == 1 ? "[#{group.slug}] #{conversation.subject}" : "Re: [#{group.slug}] #{conversation.subject}"
     mail.headers({
         'Precedence' => 'list',


### PR DESCRIPTION
More context in #8.

This fixes the issue by always using group email as the from address. The previous behaviour sometimes used the senders account email as the from header. Since this would have been from a domain which the email couldn't have been signed against, the message may have been flagged as suspicious.

@hiemanshu I don't have Lumen setup locally so I haven't been able to verify the fix.

cc @michaelsnook 