### PR TITLE
Fix/ensure consistent from header, take 2

### DIFF
--- a/models/conversation_post_bcc.rb
+++ b/models/conversation_post_bcc.rb
@@ -66,7 +66,8 @@ class ConversationPostBcc
                 
     mail = Mail.new
     mail.to = group.email
-    mail.from = group.email 
+    mail.from = "#{conversation_post.account.name} <#{group.email}>"
+    mail.sender = group.email('-noreply')
     mail.subject = conversation.visible_conversation_posts.count == 1 ? "[#{group.slug}] #{conversation.subject}" : "Re: [#{group.slug}] #{conversation.subject}"
     mail.headers({
         'Precedence' => 'list',


### PR DESCRIPTION
The previous pr (#9 ) created another issue because there was no no-reply address to silence auto-responses having to do with failed deliveries. Also it removed the author's name entirely, so I reverted the parts of the of `send_email` method to set From and Sender, but without the more complex `from_address` logic that Vim removed. 