### PR TITLE
Try and clarify post replies will go to the group

### DIFF
--- a/app/views/emails/conversation_post.erb
+++ b/app/views/emails/conversation_post.erb
@@ -9,7 +9,7 @@
   </head>
   <body>
     <span style="display:none !important;visibility: hidden;opacity: 0;font-size: 0"><%=(n = Nokogiri::HTML.parse(conversation_post.body)).css('style').remove; n.text[0..255]%><br /></span>
-    <span style="font-size: 80%">Respond by replying above this line or visit <a href="http://<%=Config['DOMAIN']%>/conversations/<%=conversation_post.conversation.slug%>">http://<%=Config['DOMAIN']%>/conversations/<%=conversation_post.conversation.slug%></a></span>
+    <span style="font-size: 80%">Respond to the group by replying above this line or visit <a href="http://<%=Config['DOMAIN']%>/conversations/<%=conversation_post.conversation.slug%>">http://<%=Config['DOMAIN']%>/conversations/<%=conversation_post.conversation.slug%></a></span>
     <br />
 
     <% if group.didyouknows.count > 0 %>

--- a/models/conversation_post_bcc.rb
+++ b/models/conversation_post_bcc.rb
@@ -66,7 +66,8 @@ class ConversationPostBcc
                 
     mail = Mail.new
     mail.to = group.email
-    mail.from = "#{conversation_post.account.name} <#{group.email}>"
+    mail.from = "#{conversation_post.account.name} via Open Wide <#{group.email}>"
+    mail.reply_to = "#{conversation_post.account.name} via Open Wide <#{group.email}>"
     mail.sender = group.email('-noreply')
     mail.subject = conversation.visible_conversation_posts.count == 1 ? "[#{group.slug}] #{conversation.subject}" : "Re: [#{group.slug}] #{conversation.subject}"
     mail.headers({


### PR DESCRIPTION
For email notifications of group posts, this:
• Changes the from address to _Name via **OPEN Wide**_
• Adds a reply-to header with the same name as above (was previously just _Name_ giving the impression it was a direct reply)
• Updates the help text at the top of the email from _Respond by replying above this line or visit_ to _Respond **to the group** by replying above this line or visit_
